### PR TITLE
Bump 0.7.7, drop six and pin ipopt

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "espei" %}
-{% set version = "0.7.6" %}
-{% set sha256 = "371338f1dfea6bd5022ff0df96793962b316a2e21879319badeafe6e60c05c86" %}
+{% set version = "0.7.7" %}
+{% set sha256 = "70526156aee964dd2ceaaac21a06ba6a0ba8ad8efe3ed3c36137a31ff3008eb8" %}
 
 package:
   name: {{ name|lower }}
@@ -26,7 +26,7 @@ requirements:
     - numpy
     - scipy
     - sympy >=1.3
-    - six
+    - ipopt <3.13
     - dask >=2
     - distributed >=2
     - tinydb >=3.8


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


ipopt is pinned due to https://github.com/pycalphad/pycalphad/issues/271

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
